### PR TITLE
Add msg.topic pull to force update from SmartThings

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ Device changes are received through the webhook you set up at SmartThings Develo
 Portal.
 
 All device nodes can receive at its input a message with the ```msg.topic``` of
-**update** to force the output of the current device state. This is useful when
+**update** to force the output of the current saved device state. This is useful when
 handling a request, for example.
+If you want to pull the current status from SmartThings, you can send a message with the ```msg.topic``` of **pull**;
 
 Some devices can have their state changed. You can turn on a light, change
 level and color, or, open your door.

--- a/smartthings/smartthings-color-temperature.js
+++ b/smartthings/smartthings-color-temperature.js
@@ -69,6 +69,33 @@ module.exports = function(RED) {
             this.reportState(send, done);
         };
 
+        this.pullState = function(){
+            this.conf.getDeviceStatus(this.device,"main").then( (status) => {
+                console.debug("ColorTemperatureDevice("+this.name+") Status Refreshed");
+
+                let state = {};
+
+                if(status["switch"] !== undefined && status["switch"]["switch"] !== undefined){
+                    state.value = (status["switch"]["switch"]["value"].toLowerCase() === "on" ? 1 : 0);
+                }
+
+                if(status["switchLevel"] !== undefined && status["switchLevel"]["level"] !== undefined){
+                    state.level = status["switchLevel"]["level"]["value"];
+                    state.levelUnit = status["switchLevel"]["level"]["unit"];
+                }
+
+                if(status["colorTemperature"] !== undefined){
+                    state.temperature = status["colorTemperature"]["colorTemperature"]["value"];
+                    state.temperatureUnit = status["colorTemperature"]["colorTemperature"]["unit"];
+                }
+
+                this.setState(state);
+            }).catch( err => {
+                console.error("Ops... error getting device state (ColorTemperatureDevice)");
+                console.error(err);
+            });
+        };
+
         if(this.conf && this.device){
             const callback  = (evt) => {
                 console.debug("ColorTemperatureDevice("+this.name+") Callback called");
@@ -95,31 +122,7 @@ module.exports = function(RED) {
             }
 
             this.conf.registerCallback(this, this.device, callback);
-
-            this.conf.getDeviceStatus(this.device,"main").then( (status) => {
-                console.debug("ColorTemperatureDevice("+this.name+") Status Refreshed");
-
-                let state = {};
-
-                if(status["switch"] !== undefined && status["switch"]["switch"] !== undefined){
-                    state.value = (status["switch"]["switch"]["value"].toLowerCase() === "on" ? 1 : 0);
-                }
-
-                if(status["switchLevel"] !== undefined && status["switchLevel"]["level"] !== undefined){
-                    state.level = status["switchLevel"]["level"]["value"];
-                    state.levelUnit = status["switchLevel"]["level"]["unit"];
-                }
-
-                if(status["colorTemperature"] !== undefined){
-                    state.temperature = status["colorTemperature"]["colorTemperature"]["value"];
-                    state.temperatureUnit = status["colorTemperature"]["colorTemperature"]["unit"];
-                }
-
-                this.setState(state);
-            }).catch( err => {
-                console.error("Ops... error getting device state (ColorTemperatureDevice)");
-                console.error(err);
-            });
+            this.pullState();
 
             this.on('input', (msg, send, done) => {
                 send = send || function() { node.send.apply(node,arguments) };
@@ -130,6 +133,10 @@ module.exports = function(RED) {
 
                 if(msg && msg.topic !== undefined){
                     switch(msg.topic){
+                        case "pull":
+                            this.pullState();
+                            break;
+
                         case "update":
                             this.reportState(send, done, msg);
                             break;

--- a/smartthings/smartthings-humidity.js
+++ b/smartthings/smartthings-humidity.js
@@ -47,19 +47,7 @@ module.exports = function(RED) {
             this.reportState(send, done);
         };
 
-        if(this.conf && this.device){
-            const callback  = (evt) => {
-                console.debug("HumidityDevice("+this.name+") Callback called");
-                console.debug(evt);
-                if(evt["name"] == "humidity"){
-                    this.setState({
-                        value: parseFloat(evt["value"])
-                    });
-                }
-            }
-
-            this.conf.registerCallback(this, this.device, callback);
-
+        this.pullState = function(){
             this.conf.getDeviceStatus(this.device,"main/capabilities/relativeHumidityMeasurement").then( (status) => {
                 console.debug("HumidityDevice("+this.name+") Status Refreshed");
                 console.debug(status);
@@ -73,6 +61,21 @@ module.exports = function(RED) {
                 console.error("Ops... error getting device state (HumidityDevice)");
                 console.error(err);
             });
+        };
+
+        if(this.conf && this.device){
+            const callback  = (evt) => {
+                console.debug("HumidityDevice("+this.name+") Callback called");
+                console.debug(evt);
+                if(evt["name"] == "humidity"){
+                    this.setState({
+                        value: parseFloat(evt["value"])
+                    });
+                }
+            }
+
+            this.conf.registerCallback(this, this.device, callback);
+            this.pullState();
 
             this.on('input', (msg, send, done) => {
                 send = send || function() { node.send.apply(node,arguments) };
@@ -82,6 +85,10 @@ module.exports = function(RED) {
 
                 if(msg && msg.topic !== undefined){
                     switch(msg.topic){
+                        case "pull":
+                            this.pullState();
+                            break;
+
                         case "update":
                             this.reportState(send, done, msg);
                             break;

--- a/smartthings/smartthings-illuminance.js
+++ b/smartthings/smartthings-illuminance.js
@@ -46,17 +46,7 @@ module.exports = function(RED) {
             this.reportStatus(send, done);
         }
 
-        if(this.conf && this.device){
-            const callback  = (evt) => {
-                console.debug("IlluminanceDevice("+this.name+") Callback called");
-                console.debug(evt);
-                if(evt["name"] == "illuminance"){
-                    this.updateStatus(parseFloat(evt["value"]),evt["unit"]);
-                }
-            }
-
-            this.conf.registerCallback(this, this.device, callback);
-
+        this.pullStatus = function(){
             this.conf.getDeviceStatus(this.device,"main/capabilities/illuminanceMeasurement").then( (status) => {
                 console.debug("IlluminanceDevice("+this.name+") Status Refreshed");
                 console.debug(status);
@@ -70,6 +60,19 @@ module.exports = function(RED) {
                 console.error("Ops... error getting device state (IlluminanceDevice)");
                 console.error(err);
             });
+        }
+
+        if(this.conf && this.device){
+            const callback  = (evt) => {
+                console.debug("IlluminanceDevice("+this.name+") Callback called");
+                console.debug(evt);
+                if(evt["name"] == "illuminance"){
+                    this.updateStatus(parseFloat(evt["value"]),evt["unit"]);
+                }
+            }
+
+            this.conf.registerCallback(this, this.device, callback);
+            this.pullState();
 
             this.on('input', (msg, send, done) => {
                 send = send || function() { node.send.apply(node,arguments) };
@@ -79,6 +82,10 @@ module.exports = function(RED) {
 
                 if(msg && msg.topic !== undefined){
                     switch(msg.topic){
+                        case "pull":
+                            this.pullStatus();
+                            break;
+
                         case "update":
                             this.reportStatus(send, done, msg);
                             break;

--- a/smartthings/smartthings-level.js
+++ b/smartthings/smartthings-level.js
@@ -61,6 +61,28 @@ module.exports = function(RED) {
             this.reportState(send, done);
         }
 
+        this.pullState = function(value, send, done) {
+            this.conf.getDeviceStatus(this.device,"main").then( (status) => {
+                console.debug("LevelDevice("+this.name+") Status Refreshed");
+
+                let state = {};
+
+                if(status["switch"] !== undefined && status["switch"]["switch"] !== undefined){
+                    state.value = (status["switch"]["switch"]["value"].toLowerCase() === "on" ? 1 : 0);
+                }
+
+                if(status["switchLevel"] !== undefined && status["switchLevel"]["level"] !== undefined){
+                    state.level = status["switchLevel"]["level"]["value"];
+                    state.levelUnit = status["switchLevel"]["level"]["unit"];
+                }
+
+                this.setState(state);
+            }).catch( err => {
+                console.error("Ops... error getting device state (LevelDevice)");
+                console.error(err);
+            });
+        }
+
         if(this.conf && this.device){
             const callback  = (evt) => {
                 console.debug("LevelDevice("+this.name+") Callback called");
@@ -82,26 +104,7 @@ module.exports = function(RED) {
             }
 
             this.conf.registerCallback(this, this.device, callback);
-
-            this.conf.getDeviceStatus(this.device,"main").then( (status) => {
-                console.debug("LevelDevice("+this.name+") Status Refreshed");
-
-                let state = {};
-
-                if(status["switch"] !== undefined && status["switch"]["switch"] !== undefined){
-                    state.value = (status["switch"]["switch"]["value"].toLowerCase() === "on" ? 1 : 0);
-                }
-
-                if(status["switchLevel"] !== undefined && status["switchLevel"]["level"] !== undefined){
-                    state.level = status["switchLevel"]["level"]["value"];
-                    state.levelUnit = status["switchLevel"]["level"]["unit"];
-                }
-
-                this.setState(state);
-            }).catch( err => {
-                console.error("Ops... error getting device state (LevelDevice)");
-                console.error(err);
-            });
+            this.pullState();
 
             this.on('input', (msg, send, done) => {
                 send = send || function() { node.send.apply(node,arguments) };
@@ -111,6 +114,10 @@ module.exports = function(RED) {
 
                 if(msg && msg.topic !== undefined){
                     switch(msg.topic){
+                        case "pull":
+                            this.pullState();
+                            break;
+
                         case "update":
                             this.reportState(send, done, msg);
                             break;

--- a/smartthings/smartthings-motion.js
+++ b/smartthings/smartthings-motion.js
@@ -43,17 +43,7 @@ module.exports = function(RED) {
             this.reportStatus(send, done);
         }
 
-        if(this.conf && this.device){
-            const callback  = (evt) => {
-                console.debug("MotionDevice("+this.name+") Callback called");
-                console.debug(evt);
-                if(evt["name"] == "motion"){
-                    this.updateStatus((evt["value"].toLowerCase() == "active" ? 1 : 0));
-                }
-            }
-
-            this.conf.registerCallback(this, this.device, callback);
-
+        this.pullStatus = function() {
             this.conf.getDeviceStatus(this.device,"main/capabilities/motionSensor").then( (status) => {
                 console.debug("MotionDevice("+this.name+") Status Refreshed");
                 console.debug(status);
@@ -66,6 +56,19 @@ module.exports = function(RED) {
                 console.error("Ops... error getting device state (MotionDevice)");
                 console.error(err);
             });
+        }
+
+        if(this.conf && this.device){
+            const callback  = (evt) => {
+                console.debug("MotionDevice("+this.name+") Callback called");
+                console.debug(evt);
+                if(evt["name"] == "motion"){
+                    this.updateStatus((evt["value"].toLowerCase() == "active" ? 1 : 0));
+                }
+            }
+
+            this.conf.registerCallback(this, this.device, callback);
+            this.pullStatus();
 
             this.on('input', (msg, send, done) => {
                 send = send || function() { node.send.apply(node,arguments) };
@@ -75,6 +78,10 @@ module.exports = function(RED) {
 
                 if(msg && msg.topic !== undefined){
                     switch(msg.topic){
+                        case "pull":
+                            this.pullStatus();
+                            break;
+
                         case "update":
                             this.reportStatus(send, done, msg);
                             break;

--- a/smartthings/smartthings-presence.js
+++ b/smartthings/smartthings-presence.js
@@ -43,17 +43,7 @@ module.exports = function(RED) {
             this.reportStatus(send, done);
         }
 
-        if(this.conf && this.device){
-            const callback  = (evt) => {
-                console.debug("PresenceDevice("+this.name+") Callback called");
-                console.debug(evt);
-                if(evt["name"] == "presence"){
-                    this.updateStatus((evt["value"].toLowerCase() == "present" ? 1 : 0));
-                }
-            }
-
-            this.conf.registerCallback(this, this.device, callback);
-
+        this.pullStatus = function(){
             this.conf.getDeviceStatus(this.device,"main/capabilities/presenceSensor").then( (status) => {
                 console.debug("PresenceDevice("+this.name+") Status Refreshed");
                 console.debug(status);
@@ -66,7 +56,20 @@ module.exports = function(RED) {
                 console.error("Ops... error getting device state (PresenceDevice)");
                 console.error(err);
             });
+        }
 
+        if(this.conf && this.device){
+            const callback  = (evt) => {
+                console.debug("PresenceDevice("+this.name+") Callback called");
+                console.debug(evt);
+                if(evt["name"] == "presence"){
+                    this.updateStatus((evt["value"].toLowerCase() == "present" ? 1 : 0));
+                }
+            }
+
+            this.conf.registerCallback(this, this.device, callback);
+            this.pullStatus();
+            
             this.on('input', (msg, send, done) => {
                 send = send || function() { node.send.apply(node,arguments) };
                 done = done || function() { };
@@ -75,6 +78,10 @@ module.exports = function(RED) {
 
                 if(msg && msg.topic !== undefined){
                     switch(msg.topic){
+                        case "pull":
+                            this.pullStatus();
+                            break;
+
                         case "update":
                             this.reportStatus(send, done, msg);
                             break;

--- a/smartthings/smartthings-temperature.js
+++ b/smartthings/smartthings-temperature.js
@@ -47,19 +47,7 @@ module.exports = function(RED) {
             this.reportState(send, done);
         };
 
-        if(this.conf && this.device){
-            const callback  = (evt) => {
-                console.debug("TemperatureDevice("+this.name+") Callback called");
-                console.debug(evt);
-                if(evt["name"] == "temperature"){
-                    this.setState({
-                        value: parseFloat(evt["value"])
-                    });
-                }
-            }
-
-            this.conf.registerCallback(this, this.device, callback);
-
+        this.pullState = function(){
             this.conf.getDeviceStatus(this.device,"main/capabilities/temperatureMeasurement").then( (status) => {
                 console.debug("TemperatureDevice("+this.name+") Status Refreshed");
                 console.debug(status);
@@ -73,6 +61,21 @@ module.exports = function(RED) {
                 console.error("Ops... error getting device state (TemperatureDevice)");
                 console.error(err);
             });
+        };
+
+        if(this.conf && this.device){
+            const callback  = (evt) => {
+                console.debug("TemperatureDevice("+this.name+") Callback called");
+                console.debug(evt);
+                if(evt["name"] == "temperature"){
+                    this.setState({
+                        value: parseFloat(evt["value"])
+                    });
+                }
+            }
+
+            this.conf.registerCallback(this, this.device, callback);
+            this.pullState();
 
             this.on('input', (msg, send, done) => {
                 send = send || function() { node.send.apply(node,arguments) };
@@ -82,6 +85,10 @@ module.exports = function(RED) {
 
                 if(msg && msg.topic !== undefined){
                     switch(msg.topic){
+                        case "pull":
+                            this.pullState();
+                            break;
+
                         case "update":
                             this.reportState(send, done, msg);
                             break;


### PR DESCRIPTION
As discussed in #1 and in #47 it is sometimes useful to force the refresh of the status from SmartThings instead of just output the current cached status.

This PR adds this functionality while maintaining fully backwards compatibility by adding a new topic for this task.