### PR TITLE
Allow to pull complete device status from SmartThings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       "smartthings-button": "smartthings/smartthings-button.js",
       "smartthings-power-meter": "smartthings/smartthings-power-meter.js",
       "smartthings-water": "smartthings/smartthings-water.js",
-      "smartthings-scene": "smartthings/smartthings-scene.js"
+      "smartthings-scene": "smartthings/smartthings-scene.js",
+      "smartthings-status": "smartthings/smartthings-status.js"
     }
   },
   "repository": {

--- a/smartthings/smartthings-config.js
+++ b/smartthings/smartthings-config.js
@@ -59,13 +59,23 @@ module.exports = function(RED) {
             node.getDeviceStatus = function(deviceId, type){
                 console.log("getDeviceStatus:token:"+ node.token);
                 return new Promise( (resolve, reject) => {
-                    node.st.devices.getDeviceComponentStatus(deviceId, type).then(deviceStatus => {
-                        console.log("Device Status ("+deviceId+"):");
-                        console.log(deviceStatus);
-                        resolve(deviceStatus);
-                    }).catch( err => {
-                        reject(err);
-                    });
+                    if (typeof type === 'undefined') {
+                        node.st.devices.getDeviceStatus(deviceId).then(deviceStatus => {
+                            console.log("Device Status ("+deviceId+"):");
+                            console.log(deviceStatus);
+                            resolve(deviceStatus);
+                        }).catch( err => {
+                            reject(err);
+                        });
+                    } else {
+                        node.st.devices.getDeviceComponentStatus(deviceId, type).then(deviceStatus => {
+                            console.log("Device Status ("+deviceId+"):");
+                            console.log(deviceStatus);
+                            resolve(deviceStatus);
+                        }).catch( err => {
+                            reject(err);
+                        });
+                    }
                 });
             };
 

--- a/smartthings/smartthings-status.html
+++ b/smartthings/smartthings-status.html
@@ -1,0 +1,125 @@
+<script type="text/javascript">
+    RED.nodes.registerType('smartthings-node-status',{
+        category: 'Smartthings',
+        defaults: {
+            conf: {value:"", type:"smartthings-config"},
+            name: {value: ""},
+            device: {value: "", required:true}
+        },
+        paletteLabel: "Status",
+        icon: 'status.png',
+        outputs: 1,
+        inputs: 1,
+        label: function() {
+            return this.name || "Status Device";
+        },
+        oneditprepare: function(){
+            var node = this;
+
+            var getDevs = function(conf){
+
+                const confObj = RED.nodes.node(conf);
+
+                $('#node-input-device').find('option').remove().end();
+                $('<option/>',{
+                  value: "",
+                  text: "Loading..."
+                }).appendTo('#node-input-device');
+
+                $.getJSON('smartthings/'+confObj.token+'/devices/contactSensor', function(data){
+                    console.log("getDevs");
+                    console.log(data);
+
+                    $('#node-input-device').find('option').remove().end();
+
+                    $('<option/>',{
+                      value: "",
+                      text: ""
+                    }).appendTo('#node-input-device');
+
+                    for (d in data) {
+                      $('<option/>',{
+                        value: data[d].deviceId,
+                        text: data[d].label
+                      }).appendTo('#node-input-device');
+                    }
+
+                    if (node.device) {
+                      $('#node-input-device').val(node.device);
+                    }
+
+                });
+            };
+
+            if(node.conf){
+                getDevs(node.conf);
+            }
+
+            $('#node-input-device').change(function(){
+                var device = $('#node-input-device option:selected');
+                if(device.get(0) && device.val() && device.val() !== ""){
+                    $('#node-input-name').val(device.text());
+                }
+            });
+
+            $('#node-input-conf').change(function(){
+                var conf = $('#node-input-conf').val();
+                console.log("conf changed: ", conf);
+                if (conf != '_ADD_') {
+                    getDevs(conf);
+                } else {
+                    $('#node-input-device').find('option').remove().end();
+                    $('#node-input-device').val("");
+                }
+            });
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="smartthings-node-status">
+    <div class="form-row">
+        <label for="node-input-conf"><i class="fa fa-tag"></i> Account</label>
+        <input type="text" id="node-input-conf">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-device"><i class="fa fa-tag"></i> Device</label>
+        <select type="text" id="node-input-device" style="display: inline-block; width: 70%;">
+    		  <option value="empty"></option>
+        </select>
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="smartthings-node-status">
+   <p>This Node represents a contact device.</p>
+   <h3>Input</h3>
+        <dl class="message-properties">
+            <dt class="optional">topic <span class="property-type">string</span></dt>
+            <dd><code>update</code> force the node to output the current state</dd>
+        </dl>
+   <h3>Outputs</h3>
+      <ol class="node-ports">
+         <li>Standard Output
+             <dl class="message-properties">
+                <dt>topic <span class="property-type">string</span></dt>
+                <dd>value of <code>device</code></dd>
+                <dt>payload <span class="property-type">object</span></dt>
+                <dd>Object with device status</dd>
+             </dl>
+         </li>
+      </ol>
+   <h3>Details</h3>
+   <p>
+       This node represents a contact device. It will keep device state. Every time
+       the device state changes at Smartthings, the webhook will send us the current
+       status.
+   </p>
+   <p>
+       Besides, if you need it to output the status, like when responding a http request,
+       you can use the <code>topic</code> with the <code>update</code> value to force
+       it to report.
+   </p>
+</script>

--- a/smartthings/smartthings-status.js
+++ b/smartthings/smartthings-status.js
@@ -1,0 +1,102 @@
+var Promise = require('promise');
+
+module.exports = function(RED) {
+
+    function SmartthingsStatusNode(config) {
+        RED.nodes.createNode(this, config);
+
+        let node = this;
+
+        console.debug("SmartthingsStatusNode")
+        console.debug(config);
+
+        this.conf = RED.nodes.getNode(config.conf);
+        this.name = config.name;
+        this.device = config.device;
+
+        this.currentStatus = 0;
+
+        this.reportStatus = function(send, done, original){
+            send = send || function() { node.send.apply(node,arguments) };
+            done = done || function() { };
+            let msg = {
+                topic: "device",
+                payload: {
+                    deviceId: this.device,
+                    name: this.name,
+                    status: this.currentStatus
+                }
+            };
+
+            if(original !== undefined){
+                original.payload = msg.payload;
+                Object.assign(msg,original);
+            }
+
+            send(msg);
+            done();
+        }
+
+        this.updateStatus = function(currentStatus, send, done){
+            this.currentStatus = currentStatus;
+            this.reportStatus(send, done);
+        }
+
+        this.pullStatus = function(){
+            this.conf.getDeviceStatus(this.device).then( (status) => {
+                console.debug("StatusDevice("+this.name+") Status Refreshed");
+                console.debug(status);
+
+                this.updateStatus(status);
+            }).catch( err => {
+                console.error("Ops... error getting device state (StatusDevice)");
+                console.error(err);
+            });
+        }
+
+        if(this.conf && this.device){
+            const callback  = (evt) => {
+                console.debug("StatusDevice("+this.name+") Callback called");
+                console.debug(evt);
+                if(evt){
+                    this.pullStatus();
+                }
+            }
+
+            this.conf.registerCallback(this, this.device, callback);
+            this.pullStatus();
+
+            this.on('input', (msg, send, done) => {
+                send = send || function() { node.send.apply(node,arguments) };
+                done = done || function() { };
+                console.debug("Input Message Received");
+                console.log(msg);
+
+                if(msg && msg.topic !== undefined){
+                    switch(msg.topic){
+                        case "pull":
+                            this.pullStatus();
+                            break;
+
+                        case "update":
+                            this.reportStatus(send, done, msg);
+                            break;
+
+                        default:
+                            done("Invalid topic");
+                            break;
+                    }
+                } else {
+                    done("Invalid Message");
+                }
+            });
+
+            this.on('close', () => {
+                console.debug("Closed");
+                this.conf.unregisterCallback(this, this.device, callback);
+            });
+        }
+    }
+
+    RED.nodes.registerType("smartthings-node-status", SmartthingsStatusNode);
+};


### PR DESCRIPTION
SmartThins has a lot of different devices with a lot of capabilities. For whiteware devices like refrigerators etc. there are a lot of informations available that are currently not supported.

It would make sense to add a generic status node to reveal the current device status of such devices.