### PR TITLE
Issue #35

### DIFF
--- a/smartthings/smartthings-thermostat.js
+++ b/smartthings/smartthings-thermostat.js
@@ -198,7 +198,7 @@ module.exports = function(RED) {
                         });
                         break;
 
-                    case "coolingSetpoint":
+                    case "coolingsetpoint":
                         this.setState({
                             coolingSetpoint: {
                                 value: evt["value"]
@@ -206,13 +206,13 @@ module.exports = function(RED) {
                         });
                         break;
 
-                    case "thermostatFanMode":
+                    case "thermostatfanmode":
                         this.setState({
                             thermostatFanMode: evt["value"]
                         });
                         break;
 
-                    case "heatingSetpoint":
+                    case "heatingsetpoint":
                         this.setState({
                             heatingSetpoint: {
                                 value: evt["value"]
@@ -220,7 +220,7 @@ module.exports = function(RED) {
                         });
                         break;
 
-                    case "thermostatSetpoint":
+                    case "thermostatsetpoint":
                         this.setState({
                             thermostatSetpoint: {
                                 value: evt["value"]
@@ -228,13 +228,13 @@ module.exports = function(RED) {
                         });
                         break;
 
-                    case "thermostatMode":
+                    case "thermostatmode":
                         this.setState({
                             thermostatMode: evt["value"]
                         });
                         break;
 
-                    case "thermostatOperatingState":
+                    case "thermostatoperatingstate":
                         this.setState({
                             thermostatOperatingState: evt["value"]
                         });


### PR DESCRIPTION
During the webhook call back we has a case mismatch. Since I assume the setlower was there to deal with some device specific case and changing the rest to lower didn't create ambiguity changes the rest of the case values to lower case.  Fix for issue #35. 