### PR TITLE
support-mrcool-thermostat

### DIFF
--- a/smartthings/smartthings-thermostat.js
+++ b/smartthings/smartthings-thermostat.js
@@ -337,6 +337,25 @@ module.exports = function(RED) {
                     case "thermostatmode":
                         this.conf.executeDeviceCommand(this.device,[{
                             component: "main",
+                            capability: "thermostatMode",
+                            command: "setThermostatMode",
+                            arguments: [
+                                msg.payload.value
+                            ]
+                        }]).then( (ret) => {
+                            const state = {
+                                thermostatMode: msg.payload.value
+                            };
+                            this.setState(state, send, done);
+                        }).catch( (ret) => {
+                            this.error("Error updating device");
+                            this.error(ret);
+                            done("Erro updating device");
+                        });
+                        break;
+                    case "thermostat":
+                        this.conf.executeDeviceCommand(this.device,[{
+                            component: "main",
                             capability: "thermostat",
                             command: "setThermostatMode",
                             arguments: [


### PR DESCRIPTION
My thermostat reporting the capability of thermoStatmode. The current code was sending the capability of thermostat.

Output from the smartthings cli.
`Capabilities:
┌───┬─────────────────────────────┐
│ 1 │ switch                      │
│ 2 │ temperatureMeasurement      │
│ 3 │ thermostatCoolingSetpoint   │
│ 4 │ healthCheck                 │
│ 5 │ relativeHumidityMeasurement │
│ 6 │ thermostatMode              │
│ 7 │ refresh                     │
└───┴─────────────────────────────┘
? Enter capability index or id 6

Commands:
┌───┬───────────────────────────────────────────────────────────────────────┐
│ 1 │ heat()                                                                │
│ 2 │ auto()                                                                │
│ 3 │ setThermostatMode(mode<enum {asleep, auto, autowitheco, autowithreset │
│   │ autochangeover, autochangeoveractive, autocool, autoheat              │
│   │ auxheatonly, auxiliaryemergencyheat, away, cool, custom               │
│   │ dayoff, dryair, eco, emergency heat, emergencyheat                    │
│   │ emergencyheatactive, energysavecool, energysaveheat, fanonly          │
│   │ frostguard, furnace, heat, heatingoff, home, in, manual               │
│   │ moistair, off, out, resume, rush hour, rushhour, schedule             │
│   │ southernaway}>)                                                       │
│ 4 │ cool()                                                                │
│ 5 │ emergencyHeat()                                                       │
│ 6 │ off()                                                                 │
└───┴───────────────────────────────────────────────────────────────────────┘`

Error from previous code.

`qs:                                                                                                                      
body:                                                                                                                    
  -                                                                                                                      
    component:  main                                                                                                     
    capability: thermostat                                                                                               
    command:    setThermostatMode                                                                                        
    arguments:                                                                                                           
      - dryair                                                                                                           
                                                                                                                         
                                                                                                                         
19 Jun 20:21:05 - [error] [smartthings-node-thermostat:Mr cool(thermostatMode)] Error updating device                    
19 Jun 20:21:05 - [error] [smartthings-node-thermostat:Mr cool(thermostatMode)] StatusCodeError: 422 - {"requestId":"[redacted]","error":{"code":"ConstraintViolationError","message":"The request is malformed.","detai
ls":[{"code":"NotValidValue","target":"commands[0].capability","message":"thermostat is not a valid value.","details":[]}`