### PR TITLE
feature: add windowShadeLevel

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
       "smartthings-power-meter": "smartthings/smartthings-power-meter.js",
       "smartthings-thermostat": "smartthings/smartthings-thermostat.js",
       "smartthings-three-axis": "smartthings/smartthings-threeaxis.js",
+      "smartthings-shade-level": "smartthings/smartthings-shade-level.js",
       "smartthings-smoke": "smartthings/smartthings-smoke.js",
       "smartthings-scene": "smartthings/smartthings-scene.js",
       "smartthings-status": "smartthings/smartthings-status.js",

--- a/smartthings/smartthings-shade-level.html
+++ b/smartthings/smartthings-shade-level.html
@@ -1,0 +1,140 @@
+<script type="text/javascript">
+    RED.nodes.registerType('smartthings-node-shade-level',{
+        category: 'Smartthings',
+        defaults: {
+            conf: {value:"", type:"smartthings-config"},
+            name: {value: ""},
+            device: {value: "", required:true}
+        },
+        paletteLabel: "Shade Level",
+        icon: 'light.png',
+        outputs: 1,
+        inputs: 1,
+        label: function() {
+            return this.name || "Level Device";
+        },
+        oneditprepare: function(){
+            var node = this;
+
+            var getDevs = function(conf){
+
+                const confObj = RED.nodes.node(conf);
+
+                $('#node-input-device').find('option').remove().end();
+                $('<option/>',{
+                  value: "",
+                  text: "Loading..."
+                }).appendTo('#node-input-device');
+
+                $.getJSON('smartthings/'+confObj.token+'/devices/windowShadeLevel', function(data){
+                    console.log("getDevs");
+                    console.log(data);
+
+                    $('#node-input-device').find('option').remove().end();
+
+                    $('<option/>',{
+                      value: "",
+                      text: ""
+                    }).appendTo('#node-input-device');
+
+                    for (d in data) {
+                      $('<option/>',{
+                        value: data[d].deviceId,
+                        text: data[d].label
+                      }).appendTo('#node-input-device');
+                    }
+
+                    if (node.device) {
+                      $('#node-input-device').val(node.device);
+                    }
+
+                });
+            };
+
+            if(node.conf){
+                getDevs(node.conf);
+            }
+
+            $('#node-input-device').change(function(){
+                var device = $('#node-input-device option:selected');
+                if(device.get(0) && device.val() && device.val() !== ""){
+                    $('#node-input-name').val(device.text());
+                }
+            });
+
+            $('#node-input-conf').change(function(){
+                var conf = $('#node-input-conf').val();
+                console.log("conf changed: ", conf);
+                if (conf != '_ADD_') {
+                    getDevs(conf);
+                } else {
+                    $('#node-input-device').find('option').remove().end();
+                    $('#node-input-device').val("");
+                }
+            });
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="smartthings-node-shade-level">
+    <div class="form-row">
+        <label for="node-input-conf"><i class="fa fa-tag"></i> Account</label>
+        <input type="text" id="node-input-conf">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-device"><i class="fa fa-tag"></i> Device</label>
+        <select type="text" id="node-input-device" style="display: inline-block; width: 70%;">
+    		  <option value="empty"></option>
+        </select>
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="smartthings-node-shade-level">
+   <p>This Node represents a switch device.</p>
+   <h3>Input</h3>
+        <dl class="message-properties">
+            <dt class="optional">topic <span class="property-type">string</span></dt>
+            <dd><code>update</code> force the node to output the current state</dd>
+            <dt class="optional">topic <span class="property-type">string</span></dt>
+            <dd><code>pull</code> force the node to update its current state and output it</dd>
+            <dt class="optional">topic <span class="property-type">string</span></dt>
+            <dd>
+                <code>level</code> can be used to change device state. The message
+                will be something like this where value is a number:
+                <code>
+                    {
+                        topic: "level",
+                        payload: {
+                            value: [0 - 100]
+                        }
+                    }
+                </code>
+            </dd>
+        </dl>
+   <h3>Outputs</h3>
+      <ol class="node-ports">
+         <li>Standard Output
+             <dl class="message-properties">
+                <dt>topic <span class="property-type">string</span></dt>
+                <dd>value of <code>device</code></dd>
+                <dt>payload <span class="property-type">object</span></dt>
+                <dd>Object with device status</dd>
+             </dl>
+         </li>
+      </ol>
+   <h3>Details</h3>
+   <p>
+       This node represents a level device. It will keep device state. Every time
+       the device state changes at Smartthings, the webhook will send us the current
+       state.
+   </p>
+   <p>
+       Besides, if you need it to output the status, like when responding a http request,
+       you can use the <code>topic</code> with the <code>update</code> value to force
+       it to report.
+   </p>
+</script>

--- a/smartthings/smartthings-shade-level.js
+++ b/smartthings/smartthings-shade-level.js
@@ -1,0 +1,156 @@
+var Promise = require('promise');
+
+module.exports = function(RED) {
+
+    function SmartthingsLevelNode(config) {
+        RED.nodes.createNode(this, config);
+
+        let node = this;
+
+        console.debug("SmartthingsShadeLevelNode")
+        console.debug(config);
+
+        this.conf = RED.nodes.getNode(config.conf);
+        this.name = config.name;
+        this.device = config.device;
+
+        this.currentStatus = 0;
+        this.currentLevel = 0;
+
+        this.state = {
+            value: 0,
+            level: 0,
+            levelUnit: ""
+        }
+
+        this.reportState = function(send, done, original) {
+            send = send || function() { node.send.apply(node,arguments) };
+            done = done || function() { };
+            let msg = [{
+                topic: "device",
+                payload: {
+                    deviceId: this.device,
+                    deviceType: "shadeLevel",
+                    name: this.name,
+                    value: this.state.level,
+                    timestamp: new Date().toISOString()
+                }
+            }];
+
+            if(original !== undefined){
+              msg.forEach( (m) => {
+                original.payload = m.payload;
+                Object.assign(m,original);
+              });
+            }
+
+            send(msg);
+            done();
+        }
+
+        this.setState = function(value, send, done) {
+            Object.assign(this.state, value);
+            this.reportState(send, done);
+        }
+
+        this.pullState = function(value, send, done) {
+            this.conf.getDeviceStatus(this.device,"main").then( (status) => {
+                console.debug("ShadeLevelDevice("+this.name+") Status Refreshed");
+
+                let state = {};
+
+                if(status["windowShadeLevel"] !== undefined && status["windowShadeLevel"]["shadeLevel"] !== undefined){
+                    state.level = status["windowShadeLevel"]["shadeLevel"]["value"];
+                    state.levelUnit = status["windowShadeLevel"]["shadeLevel"]["unit"];
+                }
+
+                this.setState(state);
+            }).catch( err => {
+                console.error("Ops... error getting device state (LevelDevice)");
+                console.error(err);
+            });
+        }
+
+        if(this.conf && this.device){
+            const callback  = (evt) => {
+                console.debug("ShadeLevelDevice("+this.name+") Callback called");
+                console.debug(evt);
+
+                let state = {};
+
+                switch(evt["attribute"].toLowerCase()){
+                    case "switch":
+                        state.value = (evt["value"].toLowerCase() === "on" ? 1 : 0);
+                        break;
+
+                    case "level":
+                        state.level = evt["value"];
+                        break;
+                }
+
+                this.setState(state);
+            }
+
+            this.conf.registerCallback(this, this.device, callback);
+            this.pullState();
+
+            this.on('input', (msg, send, done) => {
+                send = send || function() { node.send.apply(node,arguments) };
+                done = done || function() { };
+                console.debug("Input Message Received");
+                console.log(msg);
+
+                if(msg && msg.topic !== undefined){
+                    switch(msg.topic){
+                        case "pull":
+                            this.pullState();
+                            break;
+
+                        case "update":
+                            this.reportState(send, done, msg);
+                            break;
+
+                        case "level":
+                            if(typeof(msg.payload.value) !== 'number')
+                            {
+                                done('Error : payload.value should be a number')
+                                break;
+                            }
+
+                            this.conf.executeDeviceCommand(this.device,[{
+                                component: "main",
+                                capability: "windowShadeLevel",
+                                command: "setShadeLevel",
+                                arguments: [
+                                    msg.payload.value
+                                ]
+                            }]).then( (ret) => {
+                                const state = {
+                                    level: msg.payload.value
+                                }
+                                this.setState(state, send, done);
+                            }).catch( (ret) => {
+                                console.error("Error updating device " + ret);
+                                done("Error updating device " + ret);
+                            });
+                            break;
+
+                        default:
+                            done("Invalid topic");
+                            break;
+                    }
+                } else {
+                    done("Invalid Message");
+                }
+            });
+
+            this.on('close', () => {
+                console.debug("Closed");
+                this.conf.unregisterCallback(this, this.device, callback);
+            });
+        }
+    }
+
+    RED.nodes.registerType("smartthings-node-shade-level", SmartthingsLevelNode);
+
+};


### PR DESCRIPTION
Smartthings appears to have removed the legacy support for using the Level capability with window shades. I had been using that until it broke recently.

- I added a new node to that works with these capabilities.
- I reused the light icon as I didn't have one for shades.

Tested on my local instance of node red